### PR TITLE
Make the effect respect the camera

### DIFF
--- a/lib/Fluid.tsx
+++ b/lib/Fluid.tsx
@@ -1,14 +1,14 @@
 import { createPortal, useFrame, useThree } from '@react-three/fiber';
+import { BlendFunction } from 'postprocessing';
 import { useCallback, useMemo, useRef } from 'react';
 import { Camera, Color, Mesh, Scene, Texture, Vector2, Vector3 } from 'three';
 import { ShaderPass } from 'three/examples/jsm/Addons.js';
+import { OPTS } from './constant';
 import { Effect as FluidEffect } from './effect/Fluid';
 import { useFBOs } from './hooks/useFBOs';
 import { useMaterials } from './hooks/useMaterials';
-import { Props } from './types';
-import { OPTS } from './constant';
 import { usePointer } from './hooks/usePointer';
-import { BlendFunction } from 'postprocessing';
+import { Props } from './types';
 import { normalizeScreenHz } from './utils';
 
 type Uniforms = {
@@ -46,6 +46,7 @@ export const Fluid = ({
 }: Props) => {
     const size = useThree((three) => three.size);
     const gl = useThree((three) => three.gl);
+    const camera = useThree((three) => three.camera);
 
     const bufferScene = useMemo(() => new Scene(), []);
     const bufferCamera = useMemo(() => new Camera(), []);
@@ -104,6 +105,9 @@ export const Fluid = ({
 
     useFrame((_, delta) => {
         if (!meshRef.current || !postRef.current) return;
+
+        // Make the mesh face the camera
+        meshRef.current.quaternion.copy(camera.quaternion);
 
         for (let i = splatStack.length - 1; i >= 0; i--) {
             const { mouseX, mouseY, velocityX, velocityY } = splatStack[i];

--- a/src/example/Example2.tsx
+++ b/src/example/Example2.tsx
@@ -1,22 +1,38 @@
 import { Environment, MeshTransmissionMaterial } from '@react-three/drei';
-import { useFrame } from '@react-three/fiber';
+import { useFrame, useThree } from '@react-three/fiber';
 import { EffectComposer } from '@react-three/postprocessing';
 import { useRef } from 'react';
 import { Mesh } from 'three';
 import { Fluid, useConfig } from '../../lib';
+import Text from './Text';
 import { ThreeTunnel } from './tunel';
 
-import Text from './Text';
-
-const Torus = () => {
+export const Torus = () => {
     const meshRef = useRef<Mesh>(null);
 
-    useFrame(() => {
+    const { camera } = useThree();
+
+    useFrame(({ clock }) => {
+        // meshRef.current.rotation.y += 0.01;
+
         if (!meshRef.current) return;
 
-        meshRef.current.rotation.y += 0.01;
-        meshRef.current.rotation.x += 0.005;
+        const time = clock.getElapsedTime();
+        const cameraRadius = 10;
+        const speed = 0.25;
+
+        // Calculate camera angle
+        const cameraAngle = time * speed; // Current angle of camera around Y axis
+
+        // Only rotate horizontally (around Y axis)
+        const cameraX = Math.sin(cameraAngle) * cameraRadius;
+        const cameraY = 0; // Fixed height
+        const cameraZ = Math.cos(cameraAngle) * cameraRadius;
+
+        camera.position.set(cameraX, cameraY, cameraZ);
+        camera.lookAt(0, 0, 0);
     });
+
     return (
         <>
             <ambientLight intensity={10.1} />


### PR DESCRIPTION
When the camera is rotated around the scene, the effect doesn't work on the backside of the plane where it's rendered.
So we just make the plane always face the camera.