### PR TITLE
refactor: small optimizations.

### DIFF
--- a/lib/Fluid.tsx
+++ b/lib/Fluid.tsx
@@ -57,7 +57,7 @@ export const Fluid = ({
 
     const FBOs = useFBOs();
     const materials = useMaterials();
-    const { onPointerMove, splatStack } = usePointer({ force });
+    const splatStack = usePointer({ force });
 
     const setShaderMaterial = useCallback(
         (name: keyof ReturnType<typeof useMaterials>) => {
@@ -171,11 +171,8 @@ export const Fluid = ({
     return (
         <>
             {createPortal(
-                <mesh
-                    ref={meshRef}
-                    onPointerMove={onPointerMove}
-                    scale={[size.width, size.height, 1]}>
-                    <planeGeometry args={[2, 2, 10, 10]} />
+                <mesh ref={meshRef} scale={[size.width, size.height, 1]}>
+                    <planeGeometry args={[2, 2]} />
                 </mesh>,
                 bufferScene,
             )}

--- a/lib/hooks/usePointer.tsx
+++ b/lib/hooks/usePointer.tsx
@@ -1,5 +1,6 @@
-import { ThreeEvent, useThree } from '@react-three/fiber';
-import { useCallback, useRef } from 'react';
+import { useThree } from '@react-three/fiber';
+import { useCallback, useEffect, useRef } from 'react';
+
 import { Vector2 } from 'three';
 
 type SplatStack = {
@@ -18,7 +19,7 @@ export const usePointer = ({ force }: { force: number }) => {
     const hasMoved = useRef<boolean>(false);
 
     const onPointerMove = useCallback(
-        (event: ThreeEvent<PointerEvent>) => {
+        (event: { x: number; y: number }) => {
             const deltaX = event.x - lastMouse.current.x;
             const deltaY = event.y - lastMouse.current.y;
 
@@ -30,15 +31,24 @@ export const usePointer = ({ force }: { force: number }) => {
 
             lastMouse.current.set(event.x, event.y);
 
-            splatStack.push({
+            const splatInfo = {
                 mouseX: event.x / size.width,
                 mouseY: 1.0 - event.y / size.height,
                 velocityX: deltaX * force,
                 velocityY: -deltaY * force,
-            });
+            };
+            // console.log(splatInfo.mouseX, splatInfo.mouseY)
+            splatStack.push(splatInfo);
         },
         [force, size.height, size.width, splatStack],
     );
 
-    return { onPointerMove, splatStack };
+    useEffect(() => {
+        addEventListener('pointermove', onPointerMove);
+        return () => {
+            removeEventListener('pointermove', onPointerMove);
+        };
+    }, [onPointerMove]);
+
+    return splatStack;
 };


### PR DESCRIPTION
Hi, thanks for your library which is pretty useful. I made some small changes that don't seem to alter the final result of the fluid effect:

- Use pointermove event instead of plane raycasting to detect fluid inputs
- reduce plane geometry vertex count as the fluid effect is handlend entirely in fragment shader